### PR TITLE
Update README.md - version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The target directory
 
 ```
   - name: Deploy to Staging server
-    uses: easingthemes/ssh-deploy@v2.0.2
+    uses: easingthemes/ssh-deploy@v2.0.7
     env:
       SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}
       ARGS: "-rltgoDzvO"
@@ -73,7 +73,7 @@ jobs:
     - name: Run build task
       run: npm run build --if-present
     - name: Deploy to Server
-      uses: easingthemes/ssh-deploy@v2.0.2
+      uses: easingthemes/ssh-deploy@v2.0.7
       env:
           SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}
           ARGS: "-rltgoDzvO --delete"


### PR DESCRIPTION
It is required as node10 isn't supported and generate error

Download action repository 'easingthemes/ssh-deploy@v2.0.2'
##[error]Specified argument was out of the range of valid values. (Parameter ''using: node10' is not supported, use 'docker' or 'node12' instead.')
##[error]Fail to load /home/runner/work/_actions/easingthemes/ssh-deploy/v2.0.2/action.yml