### PR TITLE
fix: 修复 ARGS 为空时导致 rsync 执行错误问题。

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,7 +140,7 @@ const run = () => {
     sshDeploy.init({
         src: GITHUB_WORKSPACE + '/' + SOURCE || '',
         dest: TARGET || '/home/' + REMOTE_USER + '/',
-        args: [ARGS] || ['-rltgoDzvO'],
+        args: ARGS ? [ARGS] : ['-rltgoDzvO'],
         host: REMOTE_HOST,
         port: REMOTE_PORT || '22',
         username: REMOTE_USER,


### PR DESCRIPTION
由于 ARGS 非必填，当其为空时，报错：
```bash
⚠️ An error happened:(. Cannot read property 'match' of undefined TypeError: Cannot read property 'match' of undefined
    at /home/runner/work/_actions/easingthemes/ssh-deploy/v2.0.7/dist/index.js:283:16
    at Array.find (<anonymous>)
    at module.exports.250.module.exports (/home/runner/work/_actions/easingthemes/ssh-deploy/v2.0.7/dist/index.js:282:39)
    at rsync (/home/runner/work/_actions/easingthemes/ssh-deploy/v2.0.7/dist/index.js:492:13)
    at /home/runner/work/_actions/easingthemes/ssh-deploy/v2.0.7/dist/index.js:519:13
    at validateRsync (/home/runner/work/_actions/easingthemes/ssh-deploy/v2.0.7/dist/index.js:588:13)
    at Object.init (/home/runner/work/_actions/easingthemes/ssh-deploy/v2.0.7/dist/index.js:514:9)
    at run (/home/runner/work/_actions/easingthemes/ssh-deploy/v2.0.7/dist/index.js:614:15)
    at Object.676 (/home/runner/work/_actions/easingthemes/ssh-deploy/v2.0.7/dist/index.js:624:1)
    at __webpack_require__ (/home/runner/work/_actions/easingthemes/ssh-deploy/v2.0.7/dist/index.js:23:30)
 1: 0x9da7c0 node::Abort() [/home/runner/runners/2.165.2/externals/node12/bin/node]
 2: 0xa4e219  [/home/runner/runners/2.165.2/externals/node12/bin/node]
 3: 0xba5d59  [/home/runner/runners/2.165.2/externals/node12/bin/node]
 4: 0xba7b47 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [/home/runner/runners/2.165.2/externals/node12/bin/node]
 5: 0x13750d9  [/home/runner/runners/2.165.2/externals/node12/bin/node]
```