### PR TITLE
Improved error handling. Added to README.md PM key generation details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ node_modules/
 .env
 .env.test
 
+# jetbrains
+.idea

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Pass configuration with `env` vars
 
 1. `SSH_PRIVATE_KEY` [required]
 
-This should be the private key part of an ssh key pair. The public key part should be added to the authorized_keys file on the server that receives the deployment.
+This should be the private key part of an ssh key pair. 
+The public key part should be added to the authorized_keys file on the server that receives the deployment.
+
+The keys should be generated using the PEM format. You can us this command
+`ssh-keygen -m PEM -t rsa -b 4096`
 
 2. `REMOTE_HOST` [required]
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pass configuration with `env` vars
 This should be the private key part of an ssh key pair. 
 The public key part should be added to the authorized_keys file on the server that receives the deployment.
 
-The keys should be generated using the PEM format. You can us this command
+The keys should be generated using the PEM format. You can use this command
 `ssh-keygen -m PEM -t rsa -b 4096`
 
 2. `REMOTE_HOST` [required]

--- a/dist/index.js
+++ b/dist/index.js
@@ -480,26 +480,28 @@ const commandExists = __webpack_require__(677);
 const nodeCmd = __webpack_require__(428);
 const nodeRsync = __webpack_require__(250);
 
-const vars = { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
-
-console.log(vars);
+const { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
 
 const sshDeploy = (() => {
     const rsync = ({ privateKey, port, src, dest, args }) => {
         console.log(`Starting Rsync Action: ${src} to ${dest}`);
 
+        console.log(privateKey, port, src, dest, args);
+
         try {
             // RSYNC COMMAND
             nodeRsync({ src, dest, args, privateKey, ssh: false, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
                 if (error) {
-                    console.error('⚠️ Rsync error', error.message);
+                    console.error('⚠️ Rsync error', error);
+                    console.log(stderr);
+                    console.log(stdout);
                     process.abort();
                 } else {
                     console.log("✅ Rsync finished.", stdout);
                 }
             });
         } catch (err) {
-            console.error(`⚠️ An error happened:(.`, err.message, err.stack);
+            console.error(`⚠️ An error happened:(.`, err);
             process.abort();
         }
     };

--- a/dist/index.js
+++ b/dist/index.js
@@ -481,7 +481,6 @@ const nodeCmd = __webpack_require__(428);
 const nodeRsync = __webpack_require__(250);
 
 const { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
-console.log('GITHUB_WORKSPACE', GITHUB_WORKSPACE);
 
 const sshDeploy = (() => {
     const rsync = ({ privateKey, port, src, dest, args }) => {
@@ -504,14 +503,14 @@ const sshDeploy = (() => {
     };
 
     const init = ({
-                      src,
-                      dest,
-                      args,
-                      host = 'localhost',
-                      username,
-                      privateKeyContent,
-                      port
-                  }) => {
+        src,
+        dest,
+        args,
+        host = 'localhost',
+        username,
+        privateKeyContent,
+        port
+    }) => {
         validateRsync(() => {
             const privateKey = addSshKey(privateKeyContent, DEPLOY_KEY_NAME ||'deploy_key');
 
@@ -605,7 +604,7 @@ const validateInputs = (inputs) => {
         return input;
     });
 
-    if (validInputs.length !== inputs.length) {
+    if (validInputs.length !== Object.keys(inputs).length) {
         process.abort();
     }
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -489,7 +489,7 @@ const sshDeploy = (() => {
 
         try {
             // RSYNC COMMAND
-            nodeRsync({ src, dest, args, privateKey, ssh: true, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
+            nodeRsync({ src, dest, args, privateKey, ssh: false, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
                 if (error) {
                     console.error('⚠️ Rsync error', error.message);
                     process.abort();
@@ -615,7 +615,7 @@ const run = () => {
     sshDeploy.init({
         src: GITHUB_WORKSPACE + '/' + SOURCE || '',
         dest: TARGET || '/home/' + REMOTE_USER + '/',
-        args: [ARGS] || false,
+        args: ARGS ? [ARGS] : ['-rltgoDzvO'],
         host: REMOTE_HOST,
         port: REMOTE_PORT || '22',
         username: REMOTE_USER,

--- a/dist/index.js
+++ b/dist/index.js
@@ -481,18 +481,17 @@ const nodeCmd = __webpack_require__(428);
 const nodeRsync = __webpack_require__(250);
 
 const { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
+console.log('GITHUB_WORKSPACE', GITHUB_WORKSPACE);
 
 const sshDeploy = (() => {
     const rsync = ({ privateKey, port, src, dest, args }) => {
         console.log(`Starting Rsync Action: ${src} to ${dest}`);
 
-        console.log(privateKey, port, src, dest, args);
-
         try {
             // RSYNC COMMAND
-            nodeRsync({ src, dest, args, privateKey, ssh: false, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
+            nodeRsync({ src, dest, args, privateKey, ssh: true, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
                 if (error) {
-                    console.error('⚠️ Rsync error', error);
+                    console.error('⚠️ Rsync error', error.message);
                     console.log(stderr);
                     console.log(stdout);
                     process.abort();
@@ -501,7 +500,7 @@ const sshDeploy = (() => {
                 }
             });
         } catch (err) {
-            console.error(`⚠️ An error happened:(.`, err);
+            console.error(`⚠️ An error happened:(.`, err.message, err.stack);
             process.abort();
         }
     };

--- a/dist/index.js
+++ b/dist/index.js
@@ -492,8 +492,9 @@ const sshDeploy = (() => {
             nodeRsync({ src, dest, args, privateKey, ssh: true, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
                 if (error) {
                     console.error('⚠️ Rsync error', error.message);
-                    console.log(stderr);
-                    console.log(stdout);
+                    console.log('stderr: ', stderr);
+                    console.log('stdout: ', stdout);
+                    console.log('cmd: ', cmd);
                     process.abort();
                 } else {
                     console.log("✅ Rsync finished.", stdout);

--- a/dist/index.js
+++ b/dist/index.js
@@ -480,7 +480,9 @@ const commandExists = __webpack_require__(677);
 const nodeCmd = __webpack_require__(428);
 const nodeRsync = __webpack_require__(250);
 
-const { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
+const vars = { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
+
+console.log(vars);
 
 const sshDeploy = (() => {
     const rsync = ({ privateKey, port, src, dest, args }) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -596,9 +596,10 @@ const sshDeploy = (() => {
 })();
 
 const validateInputs = (inputs) => {
-    const validInputs = inputs.filter(input => {
+    const validInputs = Object.keys(inputs).filter((key) => {
+        const input = inputs[key];
         if (!input) {
-            console.error(`⚠️ ${input} is mandatory`);
+            console.error(`⚠️ ${key} is mandatory`);
         }
 
         return input;
@@ -610,7 +611,7 @@ const validateInputs = (inputs) => {
 };
 
 const run = () => {
-    validateInputs([SSH_PRIVATE_KEY, REMOTE_HOST, REMOTE_USER]);
+    validateInputs({SSH_PRIVATE_KEY, REMOTE_HOST, REMOTE_USER});
 
     sshDeploy.init({
         src: GITHUB_WORKSPACE + '/' + SOURCE || '',

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const sshDeploy = (() => {
 
         try {
             // RSYNC COMMAND
-            nodeRsync({ src, dest, args, privateKey, ssh: true, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
+            nodeRsync({ src, dest, args, privateKey, ssh: false, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
                 if (error) {
                     console.error('⚠️ Rsync error', error.message);
                     process.abort();

--- a/src/index.js
+++ b/src/index.js
@@ -6,18 +6,17 @@ const nodeCmd = require('node-cmd');
 const nodeRsync = require('rsyncwrapper');
 
 const { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
+console.log('GITHUB_WORKSPACE', GITHUB_WORKSPACE);
 
 const sshDeploy = (() => {
     const rsync = ({ privateKey, port, src, dest, args }) => {
         console.log(`Starting Rsync Action: ${src} to ${dest}`);
 
-        console.log(privateKey, port, src, dest, args);
-
         try {
             // RSYNC COMMAND
-            nodeRsync({ src, dest, args, privateKey, ssh: false, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
+            nodeRsync({ src, dest, args, privateKey, ssh: true, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
                 if (error) {
-                    console.error('⚠️ Rsync error', error);
+                    console.error('⚠️ Rsync error', error.message);
                     console.log(stderr);
                     console.log(stdout);
                     process.abort();
@@ -26,7 +25,7 @@ const sshDeploy = (() => {
                 }
             });
         } catch (err) {
-            console.error(`⚠️ An error happened:(.`, err);
+            console.error(`⚠️ An error happened:(.`, err.message, err.stack);
             process.abort();
         }
     };

--- a/src/index.js
+++ b/src/index.js
@@ -5,26 +5,28 @@ const commandExists = require('command-exists');
 const nodeCmd = require('node-cmd');
 const nodeRsync = require('rsyncwrapper');
 
-const vars = { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
-
-console.log(vars);
+const { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
 
 const sshDeploy = (() => {
     const rsync = ({ privateKey, port, src, dest, args }) => {
         console.log(`Starting Rsync Action: ${src} to ${dest}`);
 
+        console.log(privateKey, port, src, dest, args);
+
         try {
             // RSYNC COMMAND
             nodeRsync({ src, dest, args, privateKey, ssh: false, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
                 if (error) {
-                    console.error('⚠️ Rsync error', error.message);
+                    console.error('⚠️ Rsync error', error);
+                    console.log(stderr);
+                    console.log(stdout);
                     process.abort();
                 } else {
                     console.log("✅ Rsync finished.", stdout);
                 }
             });
         } catch (err) {
-            console.error(`⚠️ An error happened:(.`, err.message, err.stack);
+            console.error(`⚠️ An error happened:(.`, err);
             process.abort();
         }
     };

--- a/src/index.js
+++ b/src/index.js
@@ -121,9 +121,10 @@ const sshDeploy = (() => {
 })();
 
 const validateInputs = (inputs) => {
-    const validInputs = inputs.filter(input => {
+    const validInputs = Object.keys(inputs).filter((key) => {
+        const input = inputs[key];
         if (!input) {
-            console.error(`⚠️ ${input} is mandatory`);
+            console.error(`⚠️ ${key} is mandatory`);
         }
 
         return input;
@@ -135,7 +136,7 @@ const validateInputs = (inputs) => {
 };
 
 const run = () => {
-    validateInputs([SSH_PRIVATE_KEY, REMOTE_HOST, REMOTE_USER]);
+    validateInputs({SSH_PRIVATE_KEY, REMOTE_HOST, REMOTE_USER});
 
     sshDeploy.init({
         src: GITHUB_WORKSPACE + '/' + SOURCE || '',

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,9 @@ const sshDeploy = (() => {
             nodeRsync({ src, dest, args, privateKey, ssh: true, port, sshCmdArgs: ['-o StrictHostKeyChecking=no'], recursive: true }, (error, stdout, stderr, cmd) => {
                 if (error) {
                     console.error('⚠️ Rsync error', error.message);
-                    console.log(stderr);
-                    console.log(stdout);
+                    console.log('stderr: ', stderr);
+                    console.log('stdout: ', stdout);
+                    console.log('cmd: ', cmd);
                     process.abort();
                 } else {
                     console.log("✅ Rsync finished.", stdout);

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ const nodeCmd = require('node-cmd');
 const nodeRsync = require('rsyncwrapper');
 
 const { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
-console.log('GITHUB_WORKSPACE', GITHUB_WORKSPACE);
 
 const sshDeploy = (() => {
     const rsync = ({ privateKey, port, src, dest, args }) => {
@@ -29,14 +28,14 @@ const sshDeploy = (() => {
     };
 
     const init = ({
-                      src,
-                      dest,
-                      args,
-                      host = 'localhost',
-                      username,
-                      privateKeyContent,
-                      port
-                  }) => {
+        src,
+        dest,
+        args,
+        host = 'localhost',
+        username,
+        privateKeyContent,
+        port
+    }) => {
         validateRsync(() => {
             const privateKey = addSshKey(privateKeyContent, DEPLOY_KEY_NAME ||'deploy_key');
 
@@ -130,7 +129,7 @@ const validateInputs = (inputs) => {
         return input;
     });
 
-    if (validInputs.length !== inputs.length) {
+    if (validInputs.length !== Object.keys(inputs).length) {
         process.abort();
     }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,9 @@ const commandExists = require('command-exists');
 const nodeCmd = require('node-cmd');
 const nodeRsync = require('rsyncwrapper');
 
-const { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
+const vars = { REMOTE_HOST, REMOTE_USER, REMOTE_PORT, SSH_PRIVATE_KEY, DEPLOY_KEY_NAME, SOURCE, TARGET, ARGS, GITHUB_WORKSPACE, HOME } = process.env;
+
+console.log(vars);
 
 const sshDeploy = (() => {
     const rsync = ({ privateKey, port, src, dest, args }) => {


### PR DESCRIPTION
I was getting `Rsync error rsync exited with code 255` with no clue what's going wrong, even if I've used the exact example from the documentation. Downloaded and ran locally the node script and found out that it wasn't displaying the full error of rsync. Adding that I was able to do debugging.

So these are my changes:
* Improved error handling/logging.
* Changed of default `ARGS`  which wasn't built.
* Added to `README.md` the following note:
```
The keys should be generated using the PEM format. You can use this command
`ssh-keygen -m PEM -t rsa -b 4096`
```