### PR TITLE
action.yml: Add mising declaration for the ARGS parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: "Target directory"
     required: false
     default: "/home/REMOTE_USER/"
+  ARGS:
+    description: "Arguments to pass to rsync"
+    required: false
+    default: "-rltgoDzvO"
 outputs:
   status:
     description: "Status"


### PR DESCRIPTION
I think this is why trying to use `ARGS` in a workflow results in the following error:

```
##[warning]Unexpected input 'ARGS', valid inputs are ['SSH_PRIVATE_KEY', 'REMOTE_HOST', 'REMOTE_USER', 'REMOTE_PORT', 'SOURCE', 'TARGET']
```