### PR TITLE
 #70 - There is no Password option for Rsync SSH. Documentation is up…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The keys should be generated using the PEM format. You can use this command
 ```
 ssh-keygen -m PEM -t rsa -b 4096
 ```
+**Please Note:** You should not set a Passphrase (keep it empty) for the private key you generated.
+Because rsync ssh (used for deploy) does not support private key password to be entered as a command line parameter.
 
 ##### 2. `REMOTE_HOST` [required]
 


### PR DESCRIPTION
**What we have:**
- People see a problem while trying to use this GitHub action with a Private key secured by a passphrase.
-- Example: #70  
- There is no option to pass a password for the private key in the SSH command. So, Rsync used here won't allow us to do that.
-- Reference: Articles like that. ["When prompted, do not enter a password or passphrase"](https://www2.nrel.colostate.edu/projects/irc/public/Documents/KnowledgeBase/HowTo_SSH_DSA_Key.htm), 
-- [SSH - Available CLI Command Options](https://www.ssh.com/academy/ssh/command)

**What this PR offers:**
- We can simply ask people to create a private key without a password.
