### PR TITLE
Update actions to Node.js 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
@@ -44,4 +44,4 @@ jobs:
         npm run build --if-present
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
         language: [ 'javascript' ]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
 #         ----------------------------------------------------------------
 #         START E2E Test Specific - steps

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
 #         : ---------------------------------------------------------------
 #         : START E2E Test Specific - steps
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #         : ---------------------------------------------------------------
       #         : START E2E Test Specific - steps
@@ -169,7 +169,7 @@ jobs:
       #         ----------------------------------------------------------------
 
       - name: e2e Test ssh-deploy action - Target 1
-        uses: easingthemes/ssh-deploy@v3
+        uses: easingthemes/ssh-deploy@v4
         env:
           # Shared ENV Vars created in previous steps
           REMOTE_USER: ${{ env.TEST_USER }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -169,7 +169,7 @@ jobs:
       #         ----------------------------------------------------------------
 
       - name: e2e Test ssh-deploy action - Target 1
-        uses: easingthemes/ssh-deploy@v4
+        uses: easingthemes/ssh-deploy@main
         env:
           # Shared ENV Vars created in previous steps
           REMOTE_USER: ${{ env.TEST_USER }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run Tests
         run: npm test --if-present
       - name: Create a release - ${{ github.event.inputs.version }}
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v4
         with:
           dry_run: ${{ github.event.inputs.dryRun == 'true' }}
           extra_plugins: |

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -49,9 +49,9 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js ${{ matrix.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.NODE_VERSION }}
       - name: Commit trigger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix['node-version'] }}
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run Tests
         run: npm test --if-present
       - name: Release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v4
         with:
           dry_run: false
           extra_plugins: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-    - uses: actions/stale@v7
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'


### PR DESCRIPTION
This should fix warnings on actions:
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/stale@v7. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
